### PR TITLE
fix: dashcard series card id conversion

### DIFF
--- a/metabase.py
+++ b/metabase.py
@@ -610,7 +610,7 @@ class MetabaseApi:
                                 if id[0:6] == 'card__':
                                     c = self.card_id2name(database_name, int(id[6:]))
                                     obj_res['pseudo_table_card_name'] = '%' + k + '%' + c
-                    elif k in ['card_id', 'targetId']:
+                    elif k in ['card_id', 'targetId'] or (k == 'id' and previous_key in ['series']):
                         id = obj_res.pop(k)
                         if id:
                             n = self.card_id2name(database_name, int(id))


### PR DESCRIPTION
Account for the fact that dashcard's series have card id in `id` field rather than in `card_id` like in most other places.